### PR TITLE
Enable pickling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ complex_network/
 
 ## 🔧 Package versions
 See `environment.yml` for a list of required packages.
+
+## 🔄 Serialization
+Network objects can be pickled using Python's ``pickle`` module. The
+scattering matrix helpers use callable classes so that network instances
+can be safely serialized and used in parallel processes.

--- a/complex_network/scattering_matrices/link_matrix.py
+++ b/complex_network/scattering_matrices/link_matrix.py
@@ -10,10 +10,14 @@ import numpy as np
 # -----------------------------------------------------------------------------
 
 
-def get_propagation_matrix_closure(link) -> Callable:
-    """Standard propagation matrix for links"""
+class PropagationMatrix:
+    """Callable class representing the link propagation matrix."""
 
-    def get_propagation_matrix(k0: complex) -> np.ndarray:
+    def __init__(self, link) -> None:
+        self.link = link
+
+    def __call__(self, k0: complex) -> np.ndarray:
+        link = self.link
         return np.array(
             [
                 [
@@ -27,37 +31,51 @@ def get_propagation_matrix_closure(link) -> Callable:
             ]
         )
 
-    return get_propagation_matrix
+
+def get_propagation_matrix_closure(link) -> Callable:
+    """Return a callable object for the link propagation matrix."""
+
+    return PropagationMatrix(link)
+
+
+class PropagationMatrixInverse:
+    """Callable class for the inverse propagation matrix."""
+
+    def __init__(self, link) -> None:
+        self.link = link
+
+    def __call__(self, k0: complex) -> np.ndarray:
+        link = self.link
+        return np.array(
+            [
+                [
+                    0.0,
+                    1.0
+                    / np.exp(1j * (link.n(k0) + link.Dn) * k0 * link.length),
+                ],
+                [
+                    1.0
+                    / np.exp(1j * (link.n(k0) + link.Dn) * k0 * link.length),
+                    0.0,
+                ],
+            ]
+        )
 
 
 def get_propagation_matrix_inverse_closure(link) -> Callable:
-    """Standard propagation matrix inverse for links"""
+    """Return a callable object for the inverse propagation matrix."""
 
-    def get_propagation_matrix_inverse(k0: complex) -> np.ndarray:
-        return np.array(
-            [
-                [
-                    0.0,
-                    1.0
-                    / np.exp(1j * (link.n(k0) + link.Dn) * k0 * link.length),
-                ],
-                [
-                    1.0
-                    / np.exp(1j * (link.n(k0) + link.Dn) * k0 * link.length),
-                    0.0,
-                ],
-            ]
-        )
-
-    return get_propagation_matrix_inverse
+    return PropagationMatrixInverse(link)
 
 
-def get_propagation_matrix_derivative_closure(link) -> Callable:
-    """Standard propagation matrix derivative for links"""
+class PropagationMatrixDerivative:
+    """Callable class for the derivative of the propagation matrix."""
 
-    def get_propagation_matrix_derivative(
-        k0, variable: str = "k0"
-    ) -> np.ndarray:
+    def __init__(self, link) -> None:
+        self.link = link
+
+    def __call__(self, k0: complex, variable: str = "k0") -> np.ndarray:
+        link = self.link
         VALID_VARIABLES = ["k0", "Dn"]
 
         matrix_part = np.array(
@@ -90,4 +108,8 @@ def get_propagation_matrix_derivative_closure(link) -> Callable:
 
         return factor * matrix_part
 
-    return get_propagation_matrix_derivative
+
+def get_propagation_matrix_derivative_closure(link) -> Callable:
+    """Return a callable object for the derivative of the propagation matrix."""
+
+    return PropagationMatrixDerivative(link)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,15 @@
+import pickle
+
+from complex_network.networks.network_spec import NetworkSpec
+from complex_network.networks.network_factory import generate_network
+
+
+def main():
+    spec = NetworkSpec(network_type="delaunay", network_shape="circular", num_internal_nodes=1, num_external_nodes=2)
+    net = generate_network(spec)
+    data = pickle.dumps(net)
+    net2 = pickle.loads(data)
+    assert net2.num_nodes == net.num_nodes
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- switch scattering matrix closures to callable classes
- document pickling support
- add a small pickling regression test

## Testing
- `python -m py_compile complex_network/scattering_matrices/link_matrix.py`
- `python -m py_compile complex_network/scattering_matrices/node_matrix.py`
- `PYTHONPATH=. python tests/test_serialization.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6873a9766e0c832ea4d43359310a69bb